### PR TITLE
Added missing dependencies for the new Qt version

### DIFF
--- a/src/GSvar/PublishedVariantsWidget.cpp
+++ b/src/GSvar/PublishedVariantsWidget.cpp
@@ -4,6 +4,7 @@
 #include "ui_PublishedVariantsWidget.h"
 #include "NGSD.h"
 #include "NGSHelper.h"
+#include <QAction>
 
 PublishedVariantsWidget::PublishedVariantsWidget(QWidget* parent)
 	: QWidget(parent)

--- a/src/GSvar/VariantDetailsDockWidget.cpp
+++ b/src/GSvar/VariantDetailsDockWidget.cpp
@@ -15,6 +15,7 @@
 #include "GSvarHelper.h"
 #include "LoginManager.h"
 #include "GUIHelper.h"
+#include <QHeaderView>
 
 VariantDetailsDockWidget::VariantDetailsDockWidget(QWidget* parent)
 	: QWidget(parent)


### PR DESCRIPTION
While trying to build the project on Mac (10.15 Catalina) and on Ubuntu 20.04, I noticed error messages about missing dependencies. After having added them, everything started working.