### PR TITLE
MappingQC, Statistics.cpp: exclude spliced alignments

### DIFF
--- a/src/MappingQC/main.cpp
+++ b/src/MappingQC/main.cpp
@@ -73,7 +73,7 @@ public:
 		}
         else if(rna)
 		{
-			metrics = Statistics::mapping_rna(in, min_maqp, ref_file);
+			metrics = Statistics::mapping(in, min_maqp, ref_file);
 
             //parameters
             parameters << "-rna";

--- a/src/cppNGS/Statistics.cpp
+++ b/src/cppNGS/Statistics.cpp
@@ -220,19 +220,8 @@ QCCollection Statistics::mapping(const BedFile& bed_file, const QString& bam_fil
 		++al_total;
 		max_length = std::max(max_length, al.length());
 
-		//insert size
-		if (al.isPaired())
-		{
-			paired_end = true;
-
-			if (al.isProperPair())
-			{
-				++al_proper_paired;
-				int insert_size = std::min(abs(al.insertSize()), 999); //cap insert size at 1000
-				insert_size_sum += insert_size;
-				insert_dist.inc(insert_size, true);
-			}
-		}
+		//track if spliced alignment
+		bool spliced_alignment = false;
 
 		if (!al.isUnmapped())
 		{
@@ -248,6 +237,10 @@ QCCollection Statistics::mapping(const BedFile& bed_file, const QString& bam_fil
 				if (op.Type==BAM_CSOFT_CLIP || op.Type==BAM_CHARD_CLIP)
 				{
 					bases_clipped += op.Length;
+				}
+				else if (op.Type==BAM_CREF_SKIP)
+				{
+					spliced_alignment = true;
 				}
 			}
 
@@ -292,6 +285,25 @@ QCCollection Statistics::mapping(const BedFile& bed_file, const QString& bam_fil
 							gc_reads[bin] += 1.0/indices.count();
 						}
 					}
+				}
+			}
+		}
+
+		//insert size
+		if (al.isPaired())
+		{
+			paired_end = true;
+
+			if (al.isProperPair())
+			{
+				++al_proper_paired;
+
+				//if alignment is spliced, exclude it from insert size calculation
+				if (!spliced_alignment)
+				{
+					int insert_size = std::min(abs(al.insertSize()), 999); //cap insert size at 1000
+					insert_size_sum += insert_size;
+					insert_dist.inc(insert_size, true);
 				}
 			}
 		}
@@ -460,200 +472,6 @@ QCCollection Statistics::mapping(const BedFile& bed_file, const QString& bam_fil
 	return output;
 }
 
-QCCollection Statistics::mapping_rna(const QString &bam_file, int min_mapq, const QString& ref_file)
-{
-	//open BAM file
-	BamReader reader(bam_file, ref_file);
-
-	//init counts
-	int al_total = 0;
-	int al_mapped = 0;
-	int al_ontarget = 0;
-	int al_dup = 0;
-	int al_proper_paired = 0;
-	double bases_trimmed = 0;
-	double bases_mapped = 0;
-	double bases_clipped = 0;
-	double insert_size_sum = 0;
-	Histogram insert_dist(0, 999, 5);
-	long long bases_usable = 0;
-	int max_length = 0;
-	bool paired_end = false;
-
-	//hash a read until its paired read occurs
-	QMap<QString, QPair<QList<CigarOp>, int>> read_hash;
-
-	//iterate through all alignments
-	int last_chr_id = -1;
-	BamAlignment al;
-	while (reader.getNextAlignment(al))
-	{
-		//skip secondary alignments
-		if (al.isSecondaryAlignment() || al.isSupplementaryAlignment()) continue;
-
-		//empty hash if new reference sequence (chromosome) started
-		if (al.chromosomeID() != last_chr_id)
-		{
-			read_hash.clear();
-		}
-		last_chr_id = al.chromosomeID();
-
-		++al_total;
-		max_length = std::max(max_length, al.length());
-
-		//insert size
-		if (al.isPaired())
-		{
-			paired_end = true;
-			if (al.isProperPair())
-			{
-				++al_proper_paired;
-
-				int insert_size = abs(al.insertSize());
-
-				//is the the paired read already present in the hash?
-				QString key = al.name();
-				auto search_result = read_hash.find(key);
-				if(search_result == read_hash.end())
-				{
-					read_hash.insert(key, qMakePair(al.cigarData(), al.start()-1));
-				}
-				else
-				{
-					//compute the insert size using information of both reads
-					int start1 = search_result->second;                             // Start pos read1
-					int start2 = al.start()-1;                                      // Start pos read2
-					int end1 = start1;                                              // End pos read1
-					int end2 = start2;                                              // End pos read2
-
-					//sweep over read1 and substract the introns from the insert size
-					foreach(const CigarOp& op, search_result->first)
-					{
-						end1 += op.Length;
-
-						// If the read spans an intron, decrease the insert size
-						if(op.Type==BAM_CREF_SKIP)
-						{
-							insert_size -= op.Length;
-						}
-
-						// Stop if read2 was reached
-						if(end1 >= start2) break;
-					}
-
-					//sweep over read2 and substract the introns that starts after read1's end
-					QList<CigarOp> cigar2 = al.cigarData();
-					foreach(const CigarOp& op, cigar2)
-					{
-						// Do not consider parts that were fully overlapped by read1
-						if(end2 + (int)op.Length < end1)
-						{
-							end2 += op.Length;
-							continue;
-						}
-
-						end2 += op.Length;
-
-						// If the read spans an intron, decrease the insert size
-						if(op.Type==BAM_CREF_SKIP)
-						{
-							insert_size -= op.Length;
-						}
-					}
-
-					insert_size = std::min(insert_size, 999); // cap insert size at 1000
-					insert_size_sum += 2 * insert_size;     // Twice because the sum is divided by every read of pairs
-					insert_dist.inc(insert_size, true);
-
-					// The hashed read1 is not needed any more
-					read_hash.erase(search_result);
-				}
-			}
-		}
-
-		if (!al.isUnmapped())
-		{
-			++al_mapped;
-
-			//calculate soft/hard-clipped bases
-			bases_mapped += al.length();
-			const QList<CigarOp> cigar_data = al.cigarData();
-			foreach(const CigarOp& op, cigar_data)
-			{
-				if (op.Type==BAM_CSOFT_CLIP || op.Type==BAM_CHARD_CLIP)
-				{
-					bases_clipped += op.Length;
-				}
-			}
-
-			//usable
-			if (reader.chromosome(al.chromosomeID()).isNonSpecial())
-			{
-				++al_ontarget;
-
-				if (!al.isDuplicate() && al.mappingQuality()>=min_mapq)
-				{
-					bases_usable += al.length();
-				}
-			}
-		}
-
-		//trimmed bases (this is not entirely correct if the first alignments are all trimmed, but saves the second pass through the data)
-		if (al.length()<max_length)
-		{
-			bases_trimmed += (max_length - al.length());
-		}
-
-		if (al.isDuplicate())
-		{
-			++al_dup;
-		}
-	}
-
-	//output
-	QCCollection output;
-	addQcValue(output, "QC:2000019", "trimmed base percentage", 100.0 * bases_trimmed / al_total / max_length);
-	addQcValue(output, "QC:2000052", "clipped base percentage", 100.0 * bases_clipped / bases_mapped);
-	addQcValue(output, "QC:2000020", "mapped read percentage", 100.0 * al_mapped / al_total);
-	addQcValue(output, "QC:2000021", "on-target read percentage", 100.0 * al_ontarget / al_total);
-	if (paired_end)
-	{
-		addQcValue(output, "QC:2000022", "properly-paired read percentage", 100.0 * al_proper_paired / al_total);
-		addQcValue(output, "QC:2000023", "insert size", insert_size_sum / al_proper_paired);
-	}
-	else
-	{
-		addQcValue(output, "QC:2000022", "properly-paired read percentage", "n/a (single end)");
-		addQcValue(output, "QC:2000023", "insert size", "n/a (single end)");
-	}
-	if (al_dup==0)
-	{
-		addQcValue(output, "QC:2000024", "duplicate read percentage", "n/a (duplicates not marked or removed during data analysis)");
-	}
-	else
-	{
-		addQcValue(output, "QC:2000024", "duplicate read percentage", 100.0 * al_dup / al_total);
-	}
-	addQcValue(output, "QC:2000050", "bases usable (MB)", (double)bases_usable / 1000000.0);
-
-	//add insert size distribution plot
-	if (paired_end)
-	{
-		LinePlot plot2;
-		plot2.setXLabel("insert size");
-		plot2.setYLabel("reads [%]");
-		plot2.setXValues(insert_dist.xCoords());
-		plot2.addLine(insert_dist.yCoords(true));
-
-		QString plotname = Helper::tempFileName(".png");
-		plot2.store(plotname);
-		addQcPlot(output, "QC:2000038","insert size distribution plot", plotname);
-		QFile::remove(plotname);
-	}
-
-	return output;
-}
-
 QCCollection Statistics::mapping(const QString &bam_file, int min_mapq, const QString& ref_file)
 {
 	//open BAM file
@@ -684,19 +502,8 @@ QCCollection Statistics::mapping(const QString &bam_file, int min_mapq, const QS
 		++al_total;
 		max_length = std::max(max_length, al.length());
 
-		//insert size
-		if (al.isPaired())
-		{
-			paired_end = true;
-
-			if (al.isProperPair())
-			{
-				++al_proper_paired;
-				const int insert_size = std::min(abs(al.insertSize()),  999); //cap insert size at 1000
-				insert_size_sum += insert_size;
-				insert_dist.inc(insert_size, true);
-			}
-		}
+		//track if spliced alignment
+		bool spliced_alignment = false;
 
 		if (!al.isUnmapped())
 		{
@@ -711,6 +518,10 @@ QCCollection Statistics::mapping(const QString &bam_file, int min_mapq, const QS
 				{
 					bases_clipped += op.Length;
 				}
+				else if (op.Type==BAM_CREF_SKIP)
+				{
+					spliced_alignment = true;
+				}
 			}
 
 			//usable
@@ -721,6 +532,24 @@ QCCollection Statistics::mapping(const QString &bam_file, int min_mapq, const QS
 				if (!al.isDuplicate() && al.mappingQuality()>=min_mapq)
 				{
 					bases_usable += al.length();
+				}
+			}
+		}
+
+		//insert size
+		if (al.isPaired())
+		{
+			paired_end = true;
+
+			if (al.isProperPair())
+			{
+				++al_proper_paired;
+				//if alignment is spliced, exclude it from insert size calculation
+				if (!spliced_alignment)
+				{
+					const int insert_size = std::min(abs(al.insertSize()),  999); //cap insert size at 1000
+					insert_size_sum += insert_size;
+					insert_dist.inc(insert_size, true);
 				}
 			}
 		}

--- a/src/tools-TEST/data_out/MappingQC_test07_out.qcML
+++ b/src/tools-TEST/data_out/MappingQC_test07_out.qcML
@@ -12,11 +12,12 @@
     <qualityParameter ID="qp0003" name="mapped read percentage" description="Percentage of reads that could be mapped to the reference genome." value="100.00" cvRef="QC" accession="QC:2000020"/>
     <qualityParameter ID="qp0004" name="on-target read percentage" description="Percentage of reads that could be mapped to the target region." value="100.00" cvRef="QC" accession="QC:2000021"/>
     <qualityParameter ID="qp0005" name="properly-paired read percentage" description="Percentage of properly paired reads (for paired-end reads only)." value="99.73" cvRef="QC" accession="QC:2000022"/>
-    <qualityParameter ID="qp0006" name="insert size" description="Average insert size (for paired-end reads only)." value="159.37" cvRef="QC" accession="QC:2000023"/>
+    <qualityParameter ID="qp0006" name="insert size" description="Average insert size (for paired-end reads only)." value="150.23" cvRef="QC" accession="QC:2000023"/>
     <qualityParameter ID="qp0007" name="duplicate read percentage" description="Percentage of reads removed because they were duplicates (PCR, optical, etc)." value="n/a (duplicates not marked or removed during data analysis)" cvRef="QC" accession="QC:2000024"/>
     <qualityParameter ID="qp0008" name="bases usable (MB)" description="Bases sequenced that are usable for variant calling (in megabases)." value="1.11" cvRef="QC" accession="QC:2000050"/>
-    <qualityParameter ID="qp0010" name="SNV allele frequency deviation" description="Percentage of common SNPs that deviate from the expected allele frequency (i.e. 0.0, 0.5 or 1.0 for diploid organisms)." value="n/a" cvRef="QC" accession="QC:2000051"/>
-    <attachment ID="qp0009" name="insert size distribution plot" description="Plots the paired-end insert size against the number of reads with the specific insert size." cvRef="QC" accession="QC:2000038">
+    <qualityParameter ID="qp0009" name="target region read depth" description="Average sequencing depth in target region." value="0.00" cvRef="QC" accession="QC:2000025"/>
+    <qualityParameter ID="qp0011" name="SNV allele frequency deviation" description="Percentage of common SNPs that deviate from the expected allele frequency (i.e. 0.0, 0.5 or 1.0 for diploid organisms)." value="n/a" cvRef="QC" accession="QC:2000051"/>
+    <attachment ID="qp0010" name="insert size distribution plot" description="Plots the paired-end insert size against the number of reads with the specific insert size." cvRef="QC" accession="QC:2000038">
     </attachment>
   </runQuality>
   <cvList>


### PR DESCRIPTION
This changes the mapping function in Statistics.cpp:
- mapping with ROI, mapping without ROI (WGS): exclude spliced alignments for insert size, by checking CIGAR for N

Alignments with N will normally not be present in exome or WGS.
Alignments with N in RNA will be skipped, there are ~15% spliced alignments but insert size will still be estimated accurately.

This allows us to use both mapping functions for RNA, and remove mapping_rna (which was mostly duplicate code with special handling of spliced alignments).

Currently we use MappingQC with ROI for human RNAseq which gives wrong (too large) average insert size.
I kept the "-rna" parameter in MappingQC for now, it calls the same function as "-wgs".
