### PR TITLE
Qbic data fix

### DIFF
--- a/src/cppNGSD/SomaticReportHelper.cpp
+++ b/src/cppNGSD/SomaticReportHelper.cpp
@@ -689,7 +689,7 @@ void SomaticReportHelper::saveReportData(QString filename, QString path, QString
 {
 	if (Settings::string("server_host", true).isEmpty())
 	{
-		QSharedPointer<QFile> meta_data_qbic = Helper::openFileForWriting(path+filename);
+		QSharedPointer<QFile> meta_data_qbic = Helper::openFileForWriting(path + "/" + filename);
 		meta_data_qbic.data()->write(content.toLocal8Bit());
 		meta_data_qbic->close();
 		return;
@@ -706,23 +706,6 @@ void SomaticReportHelper::saveReportData(QString filename, QString path, QString
 				add_headers
 			);
 }
-
-void SomaticReportHelper::saveFileLocal(QString filename, QString path, QString content)
-{
-	if(!QDir(path).exists()) QDir().mkdir(path);
-	QSharedPointer<QFile> file = Helper::openFileForWriting(path + "/" + filename);
-
-	QTextStream stream(file.data());
-	stream << content;
-
-	file->close();
-
-
-
-}
-
-
-
 
 double SomaticReportHelper::getCnvMaxTumorClonality(const CnvList &cnvs)
 {

--- a/src/cppNGSD/SomaticReportHelper.cpp
+++ b/src/cppNGSD/SomaticReportHelper.cpp
@@ -678,13 +678,21 @@ RtfTableRow SomaticReportHelper::overlappingCnv(const CopyNumberVariant &cnv, QB
 
 void SomaticReportHelper::saveFileOnServer(QString filename, QString path, QString content)
 {
+	if (!Settings::string("server_host", true).isEmpty())
+	{
+		QSharedPointer<QFile> meta_data_qbic = Helper::openFileForWriting(path+filename);
+		meta_data_qbic.data()->write(content.toLocal8Bit());
+		meta_data_qbic->close();
+		return;
+	}
+
 	HttpHeaders add_headers;
 	add_headers.insert("Accept", "application/json");
 	add_headers.insert("Content-Type", "application/json");
 	add_headers.insert("Content-Length", QByteArray::number(content.size()));
 	QString reply = HttpRequestHandler(HttpRequestHandler::ProxyType::NONE).post(
 				Helper::serverApiUrl()
-				+ "qbic_report_data?filename=" + QUrl(filename ).toEncoded() + "&path=" + QUrl(path).toEncoded(),
+				+ "qbic_report_data?filename=" + QUrl(filename).toEncoded() + "&path=" + QUrl(path).toEncoded(),
 				content.toLocal8Bit(),
 				add_headers
 			);

--- a/src/cppNGSD/SomaticReportHelper.cpp
+++ b/src/cppNGSD/SomaticReportHelper.cpp
@@ -678,7 +678,7 @@ RtfTableRow SomaticReportHelper::overlappingCnv(const CopyNumberVariant &cnv, QB
 
 void SomaticReportHelper::saveReportData(QString filename, QString path, QString content)
 {
-	if (!Settings::string("server_host", true).isEmpty())
+	if (Settings::string("server_host", true).isEmpty())
 	{
 		QSharedPointer<QFile> meta_data_qbic = Helper::openFileForWriting(path+filename);
 		meta_data_qbic.data()->write(content.toLocal8Bit());

--- a/src/cppNGSD/SomaticReportHelper.cpp
+++ b/src/cppNGSD/SomaticReportHelper.cpp
@@ -304,7 +304,7 @@ void SomaticReportHelper::germlineSnvForQbic(QString path_target_folder)
 	stream << "functional_class" << "\t" << "effect";
 	stream << endl;
 
-	saveFileOnServer("QBIC_germline_snv.tsv", path_target_folder, content);
+	saveReportData("QBIC_germline_snv.tsv", path_target_folder, content);
 }
 
 void SomaticReportHelper::somaticSnvForQbic(QString path_target_folder)
@@ -375,7 +375,7 @@ void SomaticReportHelper::somaticSnvForQbic(QString path_target_folder)
 
 		stream << endl;
 	}
-	saveFileOnServer("QBIC_somatic_snv.tsv", path_target_folder, content);
+	saveReportData("QBIC_somatic_snv.tsv", path_target_folder, content);
 }
 
 void SomaticReportHelper::germlineCnvForQbic(QString path_target_folder)
@@ -387,7 +387,7 @@ void SomaticReportHelper::germlineCnvForQbic(QString path_target_folder)
 	stream << "chr" << "\t" << "start" << "\t" << "end" << "\t" << "effect";
 	stream << endl;
 
-	saveFileOnServer("QBIC_germline_cnv.tsv", path_target_folder, content);
+	saveReportData("QBIC_germline_cnv.tsv", path_target_folder, content);
 }
 
 
@@ -493,7 +493,7 @@ void SomaticReportHelper::somaticCnvForQbic(QString path_target_folder)
 
 		stream << endl;
 	}
-	saveFileOnServer("QBIC_somatic_cnv.tsv", path_target_folder, content);
+	saveReportData("QBIC_somatic_cnv.tsv", path_target_folder, content);
 }
 
 void SomaticReportHelper::somaticSvForQbic(QString path_target_folder)
@@ -503,7 +503,7 @@ void SomaticReportHelper::somaticSvForQbic(QString path_target_folder)
 
 	stream << "type" << "\t" << "gene" << "\t" << "effect" << "\t" << "left_bp" << "\t" << "right_bp" << endl;
 
-	saveFileOnServer("QBIC_somatic_sv.tsv", path_target_folder, content);
+	saveReportData("QBIC_somatic_sv.tsv", path_target_folder, content);
 }
 
 void SomaticReportHelper::metaDataForQbic(QString path_target_folder)
@@ -539,7 +539,7 @@ void SomaticReportHelper::metaDataForQbic(QString path_target_folder)
 	stream << db_.getProcessingSystemData(db_.processingSystemIdFromProcessedSample(settings_.tumor_ps)).genome;
 	stream << endl;
 
-	saveFileOnServer("QBIC_metadata.tsv", path_target_folder, content);
+	saveReportData("QBIC_metadata.tsv", path_target_folder, content);
 }
 
 VariantTranscript SomaticReportHelper::selectSomaticTranscript(const Variant& variant)
@@ -676,7 +676,7 @@ RtfTableRow SomaticReportHelper::overlappingCnv(const CopyNumberVariant &cnv, QB
 	return row;
 }
 
-void SomaticReportHelper::saveFileOnServer(QString filename, QString path, QString content)
+void SomaticReportHelper::saveReportData(QString filename, QString path, QString content)
 {
 	if (!Settings::string("server_host", true).isEmpty())
 	{

--- a/src/cppNGSD/SomaticReportHelper.cpp
+++ b/src/cppNGSD/SomaticReportHelper.cpp
@@ -689,6 +689,8 @@ void SomaticReportHelper::saveReportData(QString filename, QString path, QString
 {
 	if (Settings::string("server_host", true).isEmpty())
 	{
+		if(!QDir(path).exists()) QDir().mkdir(path);
+
 		QSharedPointer<QFile> meta_data_qbic = Helper::openFileForWriting(path + "/" + filename);
 		meta_data_qbic.data()->write(content.toLocal8Bit());
 		meta_data_qbic->close();

--- a/src/cppNGSD/SomaticReportHelper.h
+++ b/src/cppNGSD/SomaticReportHelper.h
@@ -178,7 +178,7 @@ private:
 
 	RtfDocument doc_;
 
-	void saveFileOnServer(QString filename, QString path, QString content);
+	void saveReportData(QString filename, QString path, QString content);
 
 	void somaticSnvForQbic(QString path);
 	void germlineSnvForQbic(QString path);


### PR DESCRIPTION
This PR fixes a newly introduced problem when qbic data upload works only with the server. These changes make it possible to use local storage when the server settings are not specified. GlobalServiceProvider could not be applied, since it is in GSvar, and is not accessible from NGSD.