### PR TITLE
GSvar: switched Linux CI to ubuntu 20.04

### DIFF
--- a/.github/workflows/linux_machine_gcc.yml
+++ b/.github/workflows/linux_machine_gcc.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   gcc-build-and-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     services:
       mysql:
@@ -27,7 +27,9 @@ jobs:
     - name: Update OS repositories
       run: sudo apt-get update
     - name: Setup test environment
-      run: sudo apt-get -y install make g++ git python python-matplotlib qt5-default libqt5xmlpatterns5-dev libqt5sql5-mysql libqt5charts5-dev libbz2-dev liblzma-dev zlib1g-dev libcurl4 libcurl4-openssl-dev
+      run: sudo apt-get -y install make g++ git python3 python3-matplotlib qt5-default libqt5xmlpatterns5-dev libqt5sql5-mysql libqt5charts5-dev libbz2-dev liblzma-dev zlib1g-dev libcurl4 libcurl4-openssl-dev
+    - name: Create symlink for python
+      run: sudo ln -fs /bin/python3 /bin/python
     - name: Update submodules
       run: git submodule update --recursive --init
     - name: Create settings for running tests


### PR DESCRIPTION
On December 1st GitHub will disable ubuntu 18.04 in the actions. I adjusted our current environment to work with ubuntu 20.04. Since it has a newer Qt version there are several warnings during the build process, but there are not errors. Tests also work.