### PR TITLE
GSvar: hide secure token when loading files in IGV

### DIFF
--- a/src/GSvar/DatabaseServiceRemote.cpp
+++ b/src/GSvar/DatabaseServiceRemote.cpp
@@ -325,7 +325,7 @@ QByteArray DatabaseServiceRemote::makePostApiCall(QString api_path, RequestUrlPa
 {
 	try
 	{
-		 return ApiCaller().post(api_path, params, HttpHeaders(), content, true, false, true);
+		return ApiCaller().post(api_path, params, HttpHeaders(), content, false, false, true);
 	}
 	catch (Exception& e)
 	{

--- a/src/GSvar/GlobalServiceProvider.cpp
+++ b/src/GSvar/GlobalServiceProvider.cpp
@@ -168,7 +168,8 @@ void GlobalServiceProvider::loadFileInIGV(QString filename, bool init_if_not_don
 		MainWindow* mw = qobject_cast<MainWindow*>(widget);
 		if (mw!=nullptr)
 		{
-			mw->executeIGVCommands(QStringList() << "load \"" + filename + "\"", init_if_not_done);
+			if (NGSHelper::isClientServerMode()) mw->executeIGVCommands(QStringList() << "SetAccessToken " + LoginManager::userToken() + " *" + Settings::string("server_host") + "*", init_if_not_done);
+			mw->executeIGVCommands(QStringList() << "load \"" + NGSHelper::stripSecureToken(filename) + "\"", init_if_not_done);
 		}
 	}
 }

--- a/src/GSvar/IgvDialog.cpp
+++ b/src/GSvar/IgvDialog.cpp
@@ -1,5 +1,6 @@
 #include "IgvDialog.h"
 #include "GUIHelper.h"
+#include "NGSHelper.h"
 #include <QCheckBox>
 #include <QFileInfo>
 
@@ -31,7 +32,7 @@ void IgvDialog::addFile(const FileLocation& file, bool checked)
 
 	//add file
 	QTreeWidgetItem* item = new QTreeWidgetItem(QStringList() << file.id);
-	item->setToolTip(0, file.filename);
+	item->setToolTip(0, NGSHelper::stripSecureToken(file.filename));
 	if (file.exists)
 	{
 		item->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled);

--- a/src/GSvar/MainWindow.cpp
+++ b/src/GSvar/MainWindow.cpp
@@ -2574,14 +2574,12 @@ bool MainWindow::initializeIGV(QAbstractSocket& socket)
 			QStringList init_commands;
 			init_commands.append("genome " + Settings::path("igv_genome")); //genome command first, see https://github.com/igvteam/igv/issues/1094
 			init_commands.append("new");
+			if (NGSHelper::isClientServerMode()) init_commands.append("SetAccessToken " + LoginManager::userToken() + " *" + Settings::string("server_host") + "*");
 
 			//load non-BAM files
 			foreach(QString file, files_to_load)
 			{
-				if (!NGSHelper::isBamFile(file))
-				{
-					init_commands.append("load \"" + Helper::canonicalPath(file) + "\"");
-				}
+				if (!NGSHelper::isBamFile(file)) init_commands.append("load \"" + Helper::canonicalPath(file) + "\"");
 			}
 
 			//collapse tracks
@@ -2590,10 +2588,7 @@ bool MainWindow::initializeIGV(QAbstractSocket& socket)
 			//load BAM files
 			foreach(QString file, files_to_load)
 			{
-				if (NGSHelper::isBamFile(file))
-				{
-					init_commands.append("load \"" + Helper::canonicalPath(file) + "\"");
-				}
+				if (NGSHelper::isBamFile(file)) init_commands.append("load \"" + Helper::canonicalPath(file) + "\"");
 			}
 			init_commands.append("viewaspairs");
 			init_commands.append("colorBy UNEXPECTED_PAIR");

--- a/src/cppNGS/NGSHelper.cpp
+++ b/src/cppNGS/NGSHelper.cpp
@@ -786,6 +786,13 @@ bool NGSHelper::isBamFile(QString filename)
 	}
 }
 
+QString NGSHelper::stripSecureToken(QString url)
+{
+	int token_pos = url.indexOf("?token", Qt::CaseInsensitive);
+	if (token_pos > -1) url = url.left(token_pos);
+	return  url;
+}
+
 ServerInfo NGSHelper::getServerInfo()
 {
 	ServerInfo info;

--- a/src/cppNGS/NGSHelper.h
+++ b/src/cppNGS/NGSHelper.h
@@ -121,6 +121,8 @@ public:
 	static bool isRunningOnServer();
 	///Checks if a given local file or URL is a BAM file
 	static bool isBamFile(QString filename);
+	///Removes a secure token from the URL that is given to IGV
+	static QString stripSecureToken(QString url);
 
 	///Requests information about GSvarServer
 	static ServerInfo getServerInfo();

--- a/src/cppNGSD/LoginManager.cpp
+++ b/src/cppNGSD/LoginManager.cpp
@@ -154,6 +154,18 @@ void LoginManager::renewLogin()
 	LoginManager& manager = instance();
 	HttpHeaders add_headers;
 
+	QString user_login;
+	QString user_password;
+	try
+	{
+		user_login = manager.userName();
+		user_password = manager.userPassword();
+	}
+	catch (Exception& e) {
+		Log::info("The user has not logged in yet. No need to update the credentials");
+		return;
+	}
+
 	add_headers.insert("Accept", "application/json");
 	QByteArray session_info = sendGetApiRequest("session?token=" + manager.userToken(), add_headers);
 	QJsonDocument session_json = QJsonDocument::fromJson(session_info);
@@ -165,12 +177,12 @@ void LoginManager::renewLogin()
 		// request a new token, if the current one is about to expire (30 minutes in advance)
 		if ((login_time + valid_period - (0.5 * 3600 * 1000)) < QDateTime::currentDateTime().toSecsSinceEpoch())
 		{
-			if ((manager.user_login_.isEmpty()) || (manager.user_password_.isEmpty())) return;
+			if ((user_login.isEmpty()) || (user_password.isEmpty())) return;
 
 			add_headers.clear();
 			add_headers.insert("Accept", "text/plain");
 
-			QString content = "name="+manager.user_login_+"&password="+manager.user_password_;
+			QString content = "name="+user_login+"&password="+user_password;
 			manager.user_token_ = sendPostApiRequest("login", content, add_headers);
 		}
 	}


### PR DESCRIPTION
The dialog window for loading files in IGV used to show secure tokens in tool tips. Now the tokens are removed before displaying them. IGV will send the tokens inside HTTP headres when accessing files