### PR TITLE
fix: only truncate run name in samplesheet if it starts with #

### DIFF
--- a/src/cppNGSD/NGSD.cpp
+++ b/src/cppNGSD/NGSD.cpp
@@ -5893,7 +5893,8 @@ QString NGSD::createSampleSheet(int run_id, QStringList& warnings)
 	//create header
 	sample_sheet.append("[Header],");
 	sample_sheet.append("FileFormatVersion,2");
-	sample_sheet.append("RunName," + run_name.remove(0, 1));
+	if (run_name.startsWith("#")) run_name.remove(0,1);
+	sample_sheet.append("RunName," + run_name);
 	sample_sheet.append("InstrumentPlatform,NovaSeqXSeries");
 	sample_sheet.append("InstrumentType," + query.value("d_type").toString());
 	sample_sheet.append("IndexOrientation,Forward");


### PR DESCRIPTION
@marc-sturm The runname still got truncated in the samplesheet itself. Shamelessly copied your previous fix. I'm not able to compile myself at the moment so a test from your side might be needed (or just yolo 🤷).